### PR TITLE
Bugfix for referencing folder_from_settings variable outside its decl…

### DIFF
--- a/src/ScreenshotWindow.vala
+++ b/src/ScreenshotWindow.vala
@@ -364,9 +364,10 @@ namespace Screenshot {
 
         private void save_file (string file_name, string format, string folder_dir, Gdk.Pixbuf screenshot) throws GLib.Error {
             string full_file_name = "";
+            string folder_from_settings = "";
 
             if (folder_dir == "") {
-                string folder_from_settings = settings.get_string ("folder-dir");
+                folder_from_settings = settings.get_string ("folder-dir");
                 if (folder_from_settings != "" && File.new_for_path (folder_from_settings).query_exists ()) {
                     folder_dir = folder_from_settings;
                 } else {


### PR DESCRIPTION
…aration scope.

Before, the folder_from_settings variable in save_file() was declared inside the if condition.
In my case, this was leading to a problem, for example if I call the screenshot-tool from the command line
using "screenshot-tool -s", the screenshot most of the times can't be saved. The reason for that is,
that when the folder_from_settings variable is declared inside the if condition and assigned to the folder_dir
variable (which is used outside the if condition later), the memory for the folder_from_settings variable
might be already released. By playing its declaration outside the if condition it works now for me.