### PR TITLE
don't install extra.mo files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@
 ## Building, Testing, and Installation
 
 You'll need the following dependencies:
-* meson
+
+* meson >= 0.43.0
 * libcanberra-dev
 * libgdk-pixbuf2.0-dev
 * libgranite-dev
 * valac
-    
+
 Run `meson` to configure the build environment and then `ninja` to build and run automated tests
 
     meson build --prefix=/usr
     cd build
     ninja
-    
+
 To install, use `ninja install`, then execute with `io.elementary.screenshot-tool`
 
     sudo ninja install

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,7 @@
-project('io.elementary.screenshot-tool', 'vala', 'c')
+project(
+    'io.elementary.screenshot-tool', 'vala', 'c',
+    meson_version : '>= 0.43'
+)
 
 i18n = import('i18n')
 

--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -1,3 +1,4 @@
 i18n.gettext('extra',
-    args: '--directory=' + meson.source_root()
+    args: '--directory=' + meson.source_root(),
+    install: false
 )


### PR DESCRIPTION
This uses the new "install" argument to the i18n.gettext() call in meson, which is only present in version 0.43.0 and later.